### PR TITLE
Fix build on Ubuntu 19.04 & rename streamwindow

### DIFF
--- a/gui/src/streamwindow.cpp
+++ b/gui/src/streamwindow.cpp
@@ -29,8 +29,8 @@ StreamWindow::StreamWindow(const StreamSessionConnectInfo &connect_info, QWidget
 	: QMainWindow(parent)
 {
 	setAttribute(Qt::WA_DeleteOnClose);
-	setWindowTitle(qApp->applicationName());
-
+	setWindowTitle(qApp->applicationName() + " | Stream");
+		
 	session = nullptr;
 	av_widget = nullptr;
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -87,7 +87,7 @@ endif()
 
 target_include_directories(chiaki-lib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-find_package(Threads)
+find_package(Threads REQUIRED)
 target_link_libraries(chiaki-lib Threads::Threads)
 
 find_package(OpenSSL REQUIRED)


### PR DESCRIPTION
Building failed on me because find_package for threads has no "required"

" | Stream" at the end of streamwindow is useful when you need to find the window in OBS.
