### PR TITLE
Add Pyramid/Box buttons to keybindings; update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ The following features however are yet to be implemented:
 * Touchpad support (Triggering the Touchpad Button is currently possible by pressing `T` on the keyboard)
 * Rumble
 * Configurable Keybindings. Though, for the moment you can use the following:
-  * `\` -> Square
-  * `]` -> Triangle
-  * `⏎` -> X
-  * `⌫` -> Circle
+  * `⏎` -> Cross
+  * `⌫` -> Moon
+  * `\` or `X` -> Box
+  * `]` or `C` -> Pyramid
+  * `F` or `[` -> Share
   * `⇦⇧⇩⇨` -> D-Pad
   * `Esc` -> PS
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ The following features however are yet to be implemented:
 * H264 Error Concealment (FEC and active error recovery however are implemented)
 * Touchpad support (Triggering the Touchpad Button is currently possible by pressing `T` on the keyboard)
 * Rumble
-* Configurable Keybindings
+* Configurable Keybindings. Though, for the moment you can use the following:
+  * `\` -> Square
+  * `]` -> Triangle
+  * `⏎` -> X
+  * `⌫` -> Circle
+  * `⇦⇧⇩⇨` -> D-Pad
+  * `Esc` -> PS
 
 ## Installing
 

--- a/gui/src/streamsession.cpp
+++ b/gui/src/streamsession.cpp
@@ -165,10 +165,16 @@ void StreamSession::HandleKeyboardEvent(QKeyEvent *event)
 			button_mask = CHIAKI_CONTROLLER_BUTTON_MOON;
 			break;
 		case Qt::Key::Key_Backslash:
+		case Qt::Key::Key_X:
 			button_mask = CHIAKI_CONTROLLER_BUTTON_BOX;
 			break;
+		case Qt::Key::Key_C:
 		case Qt::Key::Key_BracketRight:
 			button_mask = CHIAKI_CONTROLLER_BUTTON_PYRAMID;
+			break;
+		case Qt::Key::Key_F:
+		case Qt::Key::Key_BracketLeft:
+			button_mask = CHIAKI_CONTROLLER_BUTTON_SHARE;
 			break;
 		case Qt::Key::Key_Escape:
 			button_mask = CHIAKI_CONTROLLER_BUTTON_PS;

--- a/gui/src/streamsession.cpp
+++ b/gui/src/streamsession.cpp
@@ -164,6 +164,12 @@ void StreamSession::HandleKeyboardEvent(QKeyEvent *event)
 		case Qt::Key::Key_Backspace:
 			button_mask = CHIAKI_CONTROLLER_BUTTON_MOON;
 			break;
+		case Qt::Key::Key_Backslash:
+			button_mask = CHIAKI_CONTROLLER_BUTTON_BOX;
+			break;
+		case Qt::Key::Key_BracketRight:
+			button_mask = CHIAKI_CONTROLLER_BUTTON_PYRAMID;
+			break;
 		case Qt::Key::Key_Escape:
 			button_mask = CHIAKI_CONTROLLER_BUTTON_PS;
 			break;


### PR DESCRIPTION
Okay, so I was playing Persona V and I realized that I could *almost* play through the plot heavy parts with one hand using keyboard only; I was just missing the Square and Triangle buttons. 

I know it's not the same as having configurable keybindings, but I figured this might still be useful to some people. 