### PR TITLE
Add Android Touchpad Only Control Option

### DIFF
--- a/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
@@ -74,6 +74,11 @@ class Preferences(context: Context)
 		get() = sharedPreferences.getBoolean(onScreenControlsEnabledKey, true)
 		set(value) { sharedPreferences.edit().putBoolean(onScreenControlsEnabledKey, value).apply() }
 
+	val touchpadOnlyEnabledKey get() = resources.getString(R.string.preferences_touchpad_only_key)
+	var touchpadOnlyEnabled
+		get() = sharedPreferences.getBoolean(touchpadOnlyEnabledKey, false)
+		set(value) { sharedPreferences.edit().putBoolean(touchpadOnlyEnabledKey, value).apply() }
+
 	val logVerboseKey get() = resources.getString(R.string.preferences_log_verbose_key)
 	var logVerbose
 		get() = sharedPreferences.getBoolean(logVerboseKey, false)

--- a/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
@@ -39,6 +39,7 @@ import com.metallic.chiaki.common.Preferences
 import com.metallic.chiaki.common.ext.viewModelFactory
 import com.metallic.chiaki.lib.ConnectInfo
 import com.metallic.chiaki.session.*
+import com.metallic.chiaki.touchcontrols.TouchpadOnlyFragment
 import com.metallic.chiaki.touchcontrols.TouchControlsFragment
 import kotlinx.android.synthetic.main.activity_stream.*
 
@@ -79,9 +80,22 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 		viewModel.onScreenControlsEnabled.observe(this, Observer {
 			if(onScreenControlsSwitch.isChecked != it)
 				onScreenControlsSwitch.isChecked = it
+			if(onScreenControlsSwitch.isChecked)
+				touchpadOnlySwitch.isChecked = false
 		})
 		onScreenControlsSwitch.setOnCheckedChangeListener { _, isChecked ->
 			viewModel.setOnScreenControlsEnabled(isChecked)
+			showOverlay()
+		}
+
+		viewModel.touchpadOnlyEnabled.observe(this, Observer {
+			if(touchpadOnlySwitch.isChecked != it)
+				touchpadOnlySwitch.isChecked = it
+			if(touchpadOnlySwitch.isChecked)
+				onScreenControlsSwitch.isChecked = false
+		})
+		touchpadOnlySwitch.setOnCheckedChangeListener { _, isChecked ->
+			viewModel.setTouchpadOnlyEnabled(isChecked)
 			showOverlay()
 		}
 
@@ -99,6 +113,11 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 		{
 			fragment.controllerStateCallback = { viewModel.input.touchControllerState = it }
 			fragment.onScreenControlsEnabled = viewModel.onScreenControlsEnabled
+		}
+		if(fragment is TouchpadOnlyFragment)
+		{
+			fragment.controllerStateCallback = { viewModel.input.touchControllerState = it }
+			fragment.touchpadOnlyEnabled = viewModel.touchpadOnlyEnabled
 		}
 	}
 

--- a/android/app/src/main/java/com/metallic/chiaki/stream/StreamViewModel.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/StreamViewModel.kt
@@ -35,6 +35,9 @@ class StreamViewModel(val preferences: Preferences, val logManager: LogManager, 
 	private var _onScreenControlsEnabled = MutableLiveData<Boolean>(preferences.onScreenControlsEnabled)
 	val onScreenControlsEnabled: LiveData<Boolean> get() = _onScreenControlsEnabled
 
+	private var _touchpadOnlyEnabled = MutableLiveData<Boolean>(preferences.touchpadOnlyEnabled)
+	val touchpadOnlyEnabled: LiveData<Boolean> get() = _touchpadOnlyEnabled
+
 	override fun onCleared()
 	{
 		super.onCleared()
@@ -45,5 +48,11 @@ class StreamViewModel(val preferences: Preferences, val logManager: LogManager, 
 	{
 		preferences.onScreenControlsEnabled = enabled
 		_onScreenControlsEnabled.value = enabled
+	}
+
+	fun setTouchpadOnlyEnabled(enabled: Boolean)
+	{
+		preferences.touchpadOnlyEnabled = enabled
+		_touchpadOnlyEnabled.value = enabled
 	}
 }

--- a/android/app/src/main/java/com/metallic/chiaki/touchcontrols/TouchpadOnlyFragment.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/touchcontrols/TouchpadOnlyFragment.kt
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Chiaki.
+ *
+ * Chiaki is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chiaki is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Chiaki.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.metallic.chiaki.touchcontrols
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import com.metallic.chiaki.R
+import com.metallic.chiaki.lib.ControllerState
+import kotlinx.android.synthetic.main.fragment_controls.*
+
+class TouchpadOnlyFragment : Fragment()
+{
+	private var controllerState = ControllerState()
+		private set(value)
+		{
+			val diff = field != value
+			field = value
+			if(diff)
+				controllerStateCallback?.let { it(value) }
+		}
+
+	var controllerStateCallback: ((ControllerState) -> Unit)? = null
+	var touchpadOnlyEnabled: LiveData<Boolean>? = null
+
+	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View
+			= inflater.inflate(R.layout.fragment_touchpad_only, container, false)
+
+	override fun onViewCreated(view: View, savedInstanceState: Bundle?)
+	{
+		super.onViewCreated(view, savedInstanceState)
+
+		touchpadButtonView.buttonPressedCallback = buttonStateChanged(ControllerState.BUTTON_TOUCHPAD)
+
+		touchpadOnlyEnabled?.observe(this, Observer {
+			view.visibility = if(it) View.VISIBLE else View.GONE
+		})
+	}
+
+	private fun buttonStateChanged(buttonMask: UInt) = { pressed: Boolean ->
+		controllerState = controllerState.copy().apply {
+			buttons =
+				if(pressed)
+					buttons or buttonMask
+				else
+					buttons and buttonMask.inv()
+
+		}
+	}
+}

--- a/android/app/src/main/res/layout/activity_stream.xml
+++ b/android/app/src/main/res/layout/activity_stream.xml
@@ -23,12 +23,18 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 
+    <fragment
+        android:id="@+id/touchpadOnlyFragment"
+        android:name="com.metallic.chiaki.touchcontrols.TouchpadOnlyFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/overlay"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="bottom"
-        tools:paddingRight="48dp"
+        tools:paddingRight="12dp"
         tools:paddingTop="25dp"
         android:fitsSystemWindows="true">
 
@@ -51,6 +57,17 @@
                 app:switchPadding="8dp"
                 android:layout_marginLeft="8dp"
                 android:textColor="@color/stream_text"/>
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/touchpadOnlySwitch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="200dp"
+                android:text="Touchpad only"
+                android:textColor="@color/stream_text"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:switchPadding="8dp" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/android/app/src/main/res/layout/fragment_touchpad_only.xml
+++ b/android/app/src/main/res/layout/fragment_touchpad_only.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clipChildren="false">
+
+    <com.metallic.chiaki.touchcontrols.ControlsBackgroundView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:layout_editor_absoluteX="0dp"
+        tools:layout_editor_absoluteY="90dp" />
+
+    <com.metallic.chiaki.touchcontrols.ButtonView
+        android:id="@+id/touchpadButtonView"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_marginEnd="32dp"
+        android:layout_marginBottom="8dp"
+        android:padding="8dp"
+        app:drawableIdle="@drawable/control_button_touchpad"
+        app:drawablePressed="@drawable/control_button_touchpad_pressed"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -94,6 +94,7 @@
     <!-- Don't localize these -->
     <string name="preferences_discovery_enabled_key">discovery_enabled</string>
     <string name="preferences_on_screen_controls_enabled_key">on_screen_controls_enabled</string>
+    <string name="preferences_touchpad_only_key">touchpad_only_enabled</string>
     <string name="preferences_log_verbose_key">log_verbose</string>
     <string name="preferences_import_settings_key">import_settings</string>
     <string name="preferences_export_settings_key">export_settings</string>


### PR DESCRIPTION
Hi

Thanks for this great app, I only had one problem with it on Android:

I added an option to use the touchpad button without anything else on the android client. As the DS4 controller is only supported in Andorid 10 it helps as a workaround for all those trying to play with the DS4 with games using also the touchpad (Jedi, Fallen Order for me atm :-)). Maybe also other controllers. Tested it with my Pixel 3 and Tab S6. So with this PR you are able to play without on screen controls but just show the touchpad button in the bottom right.
 
Maybe you can incorporate it. It surely isn't the cleanest solution. And as I am new to Andorid Apps, I am open to suggestions. If they are not too time consuming as I have kids, a.s.o... ;-)

Thanks for considering
Spiff