### PR TITLE
Add Stream Display Options: Normal, Zoom and Stretch

### DIFF
--- a/android/app/src/main/res/color/stream_material_button_icon_tint.xml
+++ b/android/app/src/main/res/color/stream_material_button_icon_tint.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorAccent" android:state_checked="true"/>
+    <item android:color="@android:color/white"/>
+</selector>

--- a/android/app/src/main/res/drawable/ic_display_normal.xml
+++ b/android/app/src/main/res/drawable/ic_display_normal.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:width="24dp"
+    android:height="24dp">
+    <path
+        android:pathData="M19 5H5c-1.1 0 -2 0.9 -2 2v10c0 1.1 0.9 2 2 2h14c1.1 0 2 -0.9 2 -2V7c0 -1.1 -0.9 -2 -2 -2zm0 12H5V7h14v10z"
+        android:fillColor="#000000" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_display_stretch.xml
+++ b/android/app/src/main/res/drawable/ic_display_stretch.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:width="24dp"
+    android:height="24dp">
+    <path
+        android:pathData="M7 14H5v5h5v-2H7v-3zm-2 -4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"
+        android:fillColor="#000000" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_display_zoom.xml
+++ b/android/app/src/main/res/drawable/ic_display_zoom.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:width="24dp"
+    android:height="24dp">
+    <group>
+        <clip-path
+            android:pathData="M0 0h24v24H0z" />
+        <path
+            android:pathData="M15 3l2.3 2.3 -2.89 2.87 1.42 1.42L18.7 6.7 21 9V3zM3 9l2.3 -2.3 2.87 2.89 1.42 -1.42L6.7 5.3 9 3H3zm6 12l-2.3 -2.3 2.89 -2.87 -1.42 -1.42L5.3 17.3 3 15v6zm12 -6l-2.3 2.3 -2.87 -2.89 -1.42 1.42 2.89 2.87L15 21h6z"
+            android:fillColor="#000000" />
+    </group>
+</vector>

--- a/android/app/src/main/res/layout/activity_stream.xml
+++ b/android/app/src/main/res/layout/activity_stream.xml
@@ -34,8 +34,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="bottom"
-        tools:paddingRight="12dp"
-        tools:paddingTop="25dp"
         android:fitsSystemWindows="true">
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -69,8 +67,45 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:switchPadding="8dp" />
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+            <com.google.android.material.button.MaterialButtonToggleGroup
+                android:id="@+id/displayModeToggle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:singleSelection="true"
+                app:checkedButton="@id/display_mode_normal_button">
+
+                <com.google.android.material.button.MaterialButton
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:id="@+id/display_mode_normal_button"
+                    android:layout_width="60dp"
+                    android:layout_height="wrap_content"
+                    app:icon="@drawable/ic_display_normal"
+                    app:iconTint="@color/stream_material_button_icon_tint"
+                    app:strokeColor="@color/stream_text"/>
+                <com.google.android.material.button.MaterialButton
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:id="@+id/display_mode_zoom_button"
+                    android:layout_width="60dp"
+                    android:layout_height="wrap_content"
+                    app:icon="@drawable/ic_display_zoom"
+                    app:iconTint="@color/stream_material_button_icon_tint"
+                    app:strokeColor="@color/stream_text"/>
+                <com.google.android.material.button.MaterialButton
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:id="@+id/display_mode_stretch_button"
+                    android:layout_width="60dp"
+                    android:layout_height="wrap_content"
+                    app:icon="@drawable/ic_display_stretch"
+                    app:iconTint="@color/stream_material_button_icon_tint"
+                    app:strokeColor="@color/stream_text"/>
+
+        </com.google.android.material.button.MaterialButtonToggleGroup>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>
 
 </FrameLayout>


### PR DESCRIPTION
Hi again. 

For all those Android widescreen phones in the wild I added some display scaling options to the stream view:
* Normal -> As is now
* Zoom -> Zoomed to fit the whole screen (keeps aspect ratio)
* Stretch -> Stretch to the whole screen (messes with aspect ratio)

I don't persist this setting atm, so it has to be set again for every session. I think this is what most video players do and works for me. If you think I should persist it I can add it.
Tested on my phone and tablet.

Thanks  and have a nice weekend
Spiff
