### PR TITLE
[Touchpad] Simple fix for touchpad support with controller:

### DIFF
--- a/gui/include/streamsession.h
+++ b/gui/include/streamsession.h
@@ -28,6 +28,7 @@
 
 #include <QObject>
 #include <QImage>
+#include <QMouseEvent>
 
 #if CHIAKI_GUI_ENABLE_QT_GAMEPAD
 class QGamepad;
@@ -105,6 +106,7 @@ class StreamSession : public QObject
 		VideoDecoder *GetVideoDecoder()	{ return &video_decoder; }
 
 		void HandleKeyboardEvent(QKeyEvent *event);
+		void HandleMouseEvent(QMouseEvent *event);
 
 	signals:
 		void CurrentImageUpdated();

--- a/gui/include/streamwindow.h
+++ b/gui/include/streamwindow.h
@@ -44,6 +44,8 @@ class StreamWindow: public QMainWindow
 		void keyPressEvent(QKeyEvent *event) override;
 		void keyReleaseEvent(QKeyEvent *event) override;
 		void closeEvent(QCloseEvent *event) override;
+		void mousePressEvent(QMouseEvent *event) override;
+		void mouseReleaseEvent(QMouseEvent *event) override;
 
 	private slots:
 		void SessionQuit(ChiakiQuitReason reason, const QString &reason_str);

--- a/gui/src/streamsession.cpp
+++ b/gui/src/streamsession.cpp
@@ -141,6 +141,15 @@ void StreamSession::SetLoginPIN(const QString &pin)
 	chiaki_session_set_login_pin(&session, (const uint8_t *)data.constData(), data.size());
 }
 
+void StreamSession::HandleMouseEvent(QMouseEvent *event)
+{
+	if(event->type() == QEvent::MouseButtonPress)
+		keyboard_state.buttons |= CHIAKI_CONTROLLER_BUTTON_TOUCHPAD;
+	else
+		keyboard_state.buttons &= ~CHIAKI_CONTROLLER_BUTTON_TOUCHPAD;
+	SendFeedbackState();
+}
+
 void StreamSession::HandleKeyboardEvent(QKeyEvent *event)
 {
 	uint64_t button_mask;

--- a/gui/src/streamwindow.cpp
+++ b/gui/src/streamwindow.cpp
@@ -86,6 +86,18 @@ void StreamWindow::keyReleaseEvent(QKeyEvent *event)
 		session->HandleKeyboardEvent(event);
 }
 
+void StreamWindow::mousePressEvent(QMouseEvent *event)
+{
+	if(session)
+		session->HandleMouseEvent(event);
+}
+
+void StreamWindow::mouseReleaseEvent(QMouseEvent *event)
+{
+	if(session)
+		session->HandleMouseEvent(event);
+}
+
 void StreamWindow::closeEvent(QCloseEvent *)
 {
 	if(session)


### PR DESCRIPTION
Since Linux (and others too I guess) consider touchpad to be a standard mouse, emulate
ps4 touchpad click with a mouse click in addition to "T" key.
This effectively allows me to play in my couch without having keyboard near me.