### PR TITLE
More details on build dependencies and vaapi on README. Workaround for blackscreen under Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,21 @@ You can download them [here](https://github.com/thestr4ng3r/chiaki/releases).
 
 ### Building from Source
 
-Dependencies are CMake, Qt 5 with QtMultimedia, QtOpenGL and QtSvg, FFMPEG (libavcodec with H264 is enough), libopus, OpenSSL 1.1,
+Dependencies are CMake, Qt 5 with QtMultimedia, QtOpenGL and QtSvg, FFMPEG (libavcodec with H264 is enough), libopus, OpenSSL 1.1, SDL 2,
 protoc and the protobuf Python library (only used during compilation for Nanopb).
+
+On Fedora, above dependencies can be installed via:
+
+```
+sudo dnf install cmake make qt5-qtmultimedia-devel qt5-qtsvg-devel qt5-qtbase-gui ffmpeg-devel opus-devel openssl-devel python3-protobuf protobuf-c protobuf-devel qt5-rpm-macros SDL2-devel
+```
+
+In order to utilize hardware decoding, necessary VA-API component needs to be installed separately depending on your GPU. For example on Fedora:
+
+* **Intel**: `libva-intel-driver`(majority laptop and desktop) OR `libva-intel-hybrid-driver`(most netbook with Atom processor)
+* **AMD**: Already part of default installation
+* **Nvidia**: `libva-vdpau-driver`
+
 Then, Chiaki builds just like any other CMake project:
 ```
 git submodule update --init

--- a/README.md
+++ b/README.md
@@ -41,21 +41,7 @@ You can download them [here](https://github.com/thestr4ng3r/chiaki/releases).
 ### Building from Source
 
 Dependencies are CMake, Qt 5 with QtMultimedia, QtOpenGL and QtSvg, FFMPEG (libavcodec with H264 is enough), libopus, OpenSSL 1.1, SDL 2,
-protoc and the protobuf Python library (only used during compilation for Nanopb).
-
-On Fedora, above dependencies can be installed via:
-
-```
-sudo dnf install cmake make qt5-qtmultimedia-devel qt5-qtsvg-devel qt5-qtbase-gui ffmpeg-devel opus-devel openssl-devel python3-protobuf protobuf-c protobuf-devel qt5-rpm-macros SDL2-devel
-```
-
-In order to utilize hardware decoding, necessary VA-API component needs to be installed separately depending on your GPU. For example on Fedora:
-
-* **Intel**: `libva-intel-driver`(majority laptop and desktop) OR `libva-intel-hybrid-driver`(most netbook with Atom processor)
-* **AMD**: Already part of default installation
-* **Nvidia**: `libva-vdpau-driver`
-
-Then, Chiaki builds just like any other CMake project:
+protoc and the protobuf Python library (only used during compilation for Nanopb). Then, Chiaki builds just like any other CMake project:
 ```
 git submodule update --init
 mkdir build && cd build

--- a/doc/platform-build.md
+++ b/doc/platform-build.md
@@ -1,6 +1,28 @@
 
 # Platform-specific build instructions
 
+## Fedora
+
+On Fedora, build dependencies can be installed via:
+
+```
+sudo dnf install cmake make qt5-qtmultimedia-devel qt5-qtsvg-devel qt5-qtbase-gui ffmpeg-devel opus-devel openssl-devel python3-protobuf protobuf-c protobuf-devel qt5-rpm-macros SDL2-devel
+```
+
+Then, Chiaki builds just like any other CMake project:
+```
+git submodule update --init
+mkdir build && cd build
+cmake ..
+make
+```
+
+In order to utilize hardware decoding, necessary VA-API component needs to be installed separately depending on your GPU. For example on Fedora:
+
+* **Intel**: `libva-intel-driver`(majority laptop and desktop) OR `libva-intel-hybrid-driver`(most netbook with Atom processor)
+* **AMD**: Already part of default installation
+* **Nvidia**: `libva-vdpau-driver`
+
 ## Windows
 
 Windows support is reduced to the absolute minimum for maintainability.

--- a/gui/chiaki.desktop
+++ b/gui/chiaki.desktop
@@ -2,6 +2,6 @@
 Type=Application
 Name=Chiaki
 Comment=PlayStation 4 Remote Play Client
-Exec=env QT_QPA_PLATFORM=xcb chiaki
+Exec=chiaki
 Icon=chiaki
 Categories=Game;

--- a/gui/chiaki.desktop
+++ b/gui/chiaki.desktop
@@ -2,6 +2,6 @@
 Type=Application
 Name=Chiaki
 Comment=PlayStation 4 Remote Play Client
-Exec=chiaki
+Exec=env QT_QPA_PLATFORM=xcb chiaki
 Icon=chiaki
 Categories=Game;


### PR DESCRIPTION
Add a bit more details regarding to dependencies and vaapi, using Fedora as example.

Also a workaround for #71 for users running Chiaki under Wayland.

Many thanks to this great work!