### PR TITLE
Adding manifest to build flatpak package

### DIFF
--- a/scripts/flatpak/com.github.thestr4ng3r.Chiaki.json
+++ b/scripts/flatpak/com.github.thestr4ng3r.Chiaki.json
@@ -1,0 +1,96 @@
+{
+    "app-id": "org.flatpak.Chiaki",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.14",
+    "sdk": "org.kde.Sdk",
+    "command": "chiaki",
+    "rename-icon": "chiaki",
+    "rename-desktop-file": "chiaki.desktop",
+    "separate-locales": false,
+    "finish-args": [
+	"--share=network",
+        "--share=ipc",
+	"--socket=wayland",
+	"--socket=x11",
+        "--device=all",
+        "--device=dri",
+        "--allow=bluetooth",
+	"--socket=pulseaudio",
+	"--filesystem=home",
+	"--own-name=org.kde.*",
+	"--env=DBUS_FATAL_WARNINGS=0",
+	"--talk-name=org.freedesktop.ScreenSaver"
+    ],
+    "add-extensions": {
+        "org.freedesktop.Platform.ffmpeg-full": {
+            "directory": "lib/ffmpeg",
+            "add-ld-path": ".",
+            "version": "19.08",
+            "autodownload": true,
+            "autodelete": false
+        },
+	"org.freedesktop.Platform.VAAPI.Intel": {
+            "directory": "lib/intel-vaapi-driver",
+	    "add-ld-path": "lib",
+	    "version": "19.08"
+	}
+    },
+    "modules": [
+        {
+            "name": "protobuf-compilers",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -D protoc /app/bin/protoc"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0/protoc-3.12.0-linux-x86_64.zip",
+		    "sha256": "3af5f90ad973c36bdaf5c4bd0082cfdc8881593ddf530fc6aa1442ee3d7a4e4b"
+                }
+            ]
+        },
+	{
+              "name": "ffmpeg",
+              "cleanup": [ "/include", "/lib/pkgconfig", "/share/ffmpeg/examples" ],
+              "config-opts": [
+                "--enable-shared",
+                "--disable-static",
+                "--enable-gnutls",
+                "--disable-doc",
+                "--disable-programs",
+                "--disable-encoders",
+                "--disable-muxers",
+                "--enable-encoder=png"
+              ],
+              "sources": [{
+                "type": "archive",
+                "url": "https://ffmpeg.org/releases/ffmpeg-4.2.2.tar.xz",
+                "sha256": "cb754255ab0ee2ea5f66f8850e1bd6ad5cac1cd855d0a2f4990fb8c668b0d29c"
+              }]
+        },
+        {
+            "name": "pip-install",
+            "buildsystem": "simple",
+	    "build-options": {
+              "build-args": [
+                "--share=network"
+              ]
+            },
+            "build-commands": [
+                "pip3 install --prefix=/app google&&pip3 install --prefix=/app protobuf"
+            ]
+        },
+        {
+            "name": "chiaki",
+            "buildsystem": "cmake",
+            "builddir": "true",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/thestr4ng3r/chiaki.git"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Right now, it just points directly at the Github repo and not a specific tag.  For some reason the 1.2.0 tag did not work, so I'm guessing there is a change necessary since then for this to work.  I think if you want to add it to flathub, it needs to point to a specific tag though.