### PR TITLE
gui/src/servericonwidget.cpp: add missing import of QPainterPath

### DIFF
--- a/gui/src/servericonwidget.cpp
+++ b/gui/src/servericonwidget.cpp
@@ -18,6 +18,7 @@
 #include <servericonwidget.h>
 
 #include <QPainter>
+#include <QPainterPath>
 
 ServerIconWidget::ServerIconWidget(QWidget *parent) : QWidget(parent)
 {


### PR DESCRIPTION
Otherwise building fails with the following error:

error: aggregate ‘QPainterPath path’ has incomplete type and cannot be
defined

Closes #253

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>