### PR TITLE
Headless stream

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -2,7 +2,8 @@
 set(SOURCE
 		include/chiaki-cli.h
 		src/discover.c
-		src/wakeup.c)
+		src/wakeup.c
+		src/stream.c)
 
 add_library(chiaki-cli-lib STATIC ${SOURCE})
 target_include_directories(chiaki-cli-lib PUBLIC "include")

--- a/cli/include/chiaki-cli.h
+++ b/cli/include/chiaki-cli.h
@@ -27,6 +27,7 @@ extern "C" {
 
 CHIAKI_EXPORT int chiaki_cli_cmd_discover(ChiakiLog *log, int argc, char *argv[]);
 CHIAKI_EXPORT int chiaki_cli_cmd_wakeup(ChiakiLog *log, int argc, char *argv[]);
+CHIAKI_EXPORT int chiaki_cli_cmd_stream(ChiakiLog *log, int argc, char *argv[]);
 
 #ifdef __cplusplus
 }

--- a/cli/src/main.c
+++ b/cli/src/main.c
@@ -28,7 +28,8 @@ static const char doc[] =
 	"\v"
 	"Supported commands are:\n"
 	"  discover    Discover Consoles.\n"
-	"  wakeup      Send Wakeup Packet.\n";
+	"  wakeup      Send Wakeup Packet.\n"
+	"  stream      Fetch the Stream.\n";
 
 #define ARG_KEY_VERBOSE 'v'
 
@@ -76,6 +77,8 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 				exit(call_subcmd(state, "discover", chiaki_cli_cmd_discover));
 			else if(strcmp(arg, "wakeup") == 0)
 				exit(call_subcmd(state, "wakeup", chiaki_cli_cmd_wakeup));
+			else if(strcmp(arg, "stream") == 0)
+				exit(call_subcmd(state, "stream", chiaki_cli_cmd_stream));
 			// fallthrough
 		case ARGP_KEY_END:
 			argp_usage(state);

--- a/cli/src/stream.c
+++ b/cli/src/stream.c
@@ -1,0 +1,187 @@
+/*
+ * This file is part of Chiaki.
+ *
+ * Chiaki is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chiaki is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Chiaki.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <chiaki-cli.h>
+
+#include <chiaki/session.h>
+#include <chiaki/base64.h>
+
+#include <argp.h>
+#include <string.h>
+#include <unistd.h>
+
+static char doc[] = "Request for PS4 stream.";
+
+#define ARG_KEY_HOST 'h'
+#define ARG_KEY_REGISTKEY 'r'
+#define ARG_KEY_MORNING 'm'
+
+static void audio_header_cb(ChiakiAudioHeader *header, void *user);
+static void audio_frame_cb(uint8_t *buf, size_t buf_size, void *user);
+static bool video_frame_cb(uint8_t *buf, size_t buf_size, void *user);
+
+static struct argp_option options[] = {
+	{ "host", ARG_KEY_HOST, "Host", 0, "Host to request stream from", 0 },
+	{ "registkey", ARG_KEY_REGISTKEY, "RegistKey", 0, "PS4 registration key", 0 },
+	{ "morning", ARG_KEY_MORNING, "Morning", 0, "PS4 morning encoded in base64", 0 },
+	{ 0 }
+};
+
+typedef struct arguments
+{
+	const char *host;
+	const char *registkey;
+	const char *morning;
+} Arguments;
+
+static int parse_opt(int key, char *arg, struct argp_state *state)
+{
+	Arguments *arguments = state->input;
+
+	switch(key)
+	{
+		case ARG_KEY_HOST:
+			arguments->host = arg;
+			break;
+		case ARG_KEY_REGISTKEY:
+			arguments->registkey = arg;
+			break;
+		case ARG_KEY_MORNING:
+			arguments->morning = arg;
+			break;
+		case ARGP_KEY_ARG:
+			argp_usage(state);
+			break;
+		default:
+			return ARGP_ERR_UNKNOWN;
+	}
+
+	return 0;
+}
+
+static struct argp argp = { options, parse_opt, 0, doc, 0, 0, 0 };
+
+static void audio_header_cb(ChiakiAudioHeader *header, void *user)
+{
+	uint8_t opus_id_head[0x13];
+	memcpy(opus_id_head, "OpusHead", 8);
+	opus_id_head[0x8] = 1; // version
+	opus_id_head[0x9] = header->channels;
+	uint16_t pre_skip = 3840;
+	opus_id_head[0xa] = (uint8_t)(pre_skip & 0xff);
+	opus_id_head[0xb] = (uint8_t)(pre_skip >> 8);
+	opus_id_head[0xc] = (uint8_t)(header->rate & 0xff);
+	opus_id_head[0xd] = (uint8_t)((header->rate >> 0x8) & 0xff);
+	opus_id_head[0xe] = (uint8_t)((header->rate >> 0x10) & 0xff);
+	opus_id_head[0xf] = (uint8_t)(header->rate >> 0x18);
+	uint16_t output_gain = 0;
+	opus_id_head[0x10] = (uint8_t)(output_gain & 0xff);
+	opus_id_head[0x11] = (uint8_t)(output_gain >> 8);
+	opus_id_head[0x12] = 0; // channel map
+	audio_frame_cb(opus_id_head, sizeof(opus_id_head), user);
+
+	uint64_t pre_skip_ns = 0;
+	uint8_t csd1[8] = { (uint8_t)(pre_skip_ns & 0xff), (uint8_t)((pre_skip_ns >> 0x8) & 0xff), (uint8_t)((pre_skip_ns >> 0x10) & 0xff), (uint8_t)((pre_skip_ns >> 0x18) & 0xff),
+						(uint8_t)((pre_skip_ns >> 0x20) & 0xff), (uint8_t)((pre_skip_ns >> 0x28) & 0xff), (uint8_t)((pre_skip_ns >> 0x30) & 0xff), (uint8_t)(pre_skip_ns >> 0x38)};
+	audio_frame_cb(csd1, sizeof(csd1), user);
+
+	uint64_t pre_roll_ns = 0;
+	uint8_t csd2[8] = { (uint8_t)(pre_roll_ns & 0xff), (uint8_t)((pre_roll_ns >> 0x8) & 0xff), (uint8_t)((pre_roll_ns >> 0x10) & 0xff), (uint8_t)((pre_roll_ns >> 0x18) & 0xff),
+						(uint8_t)((pre_roll_ns >> 0x20) & 0xff), (uint8_t)((pre_roll_ns >> 0x28) & 0xff), (uint8_t)((pre_roll_ns >> 0x30) & 0xff), (uint8_t)(pre_roll_ns >> 0x38)};
+	audio_frame_cb(csd2, sizeof(csd2), user);
+}
+
+static void audio_frame_cb(uint8_t *buf, size_t buf_size, void *user)
+{
+	fwrite(buf, buf_size, 1, stderr);
+}
+
+static bool video_frame_cb(uint8_t *buf, size_t buf_size, void *user)
+{
+	fwrite(buf, buf_size, 1, stderr);
+}
+
+CHIAKI_EXPORT int chiaki_cli_cmd_stream(ChiakiLog *log, int argc, char *argv[])
+{
+	Arguments arguments = { 0 };
+	error_t argp_r = argp_parse(&argp, argc, argv, ARGP_IN_ORDER, NULL, &arguments);
+	if(argp_r != 0)
+		return 1;
+
+	if(!arguments.host)
+	{
+		fprintf(stderr, "No host specified, see --help.\n");
+		return 1;
+	}
+	if(!arguments.registkey)
+	{
+		fprintf(stderr, "No registration key specified, see --help.\n");
+		return 1;
+	}
+	if(!arguments.morning)
+	{
+		fprintf(stderr, "No morning specified, see --help.\n");
+		return 1;
+	}
+	if(strlen(arguments.registkey) > 8)
+	{
+		fprintf(stderr, "Given registkey is too long.\n");
+		return 1;
+	}
+
+	ChiakiConnectInfo chiaki_connect_info;
+	size_t morning_size = sizeof(chiaki_connect_info.morning);
+	uint8_t morning[morning_size];
+	chiaki_base64_decode(arguments.morning, strlen(arguments.morning), morning, &morning_size);
+	memcpy(chiaki_connect_info.morning, morning, morning_size);
+	chiaki_connect_info.host = arguments.host;
+	memcpy(chiaki_connect_info.regist_key, arguments.registkey, sizeof(chiaki_connect_info.regist_key));
+
+	ChiakiConnectVideoProfile video_profile;
+	video_profile.width = 640;
+	video_profile.height = 360;
+	video_profile.max_fps = 30;
+	video_profile.bitrate = 128;
+	chiaki_connect_info.video_profile = video_profile;
+
+	ChiakiSession session;
+	ChiakiErrorCode err;
+	err = chiaki_session_init(&session, &chiaki_connect_info, NULL);
+	if(err != CHIAKI_ERR_SUCCESS)
+		return 2;
+
+	ChiakiAudioSink audio_sink;
+	audio_sink.header_cb = audio_header_cb;
+	audio_sink.frame_cb = audio_frame_cb;
+	chiaki_session_set_audio_sink(&session, &audio_sink);
+
+	// Video seems to work fine for now, commenting this so it doesn't
+	// interfere with my attempts to get audio working.
+	// chiaki_session_set_video_sample_cb(&session, video_frame_cb, NULL);
+
+	err = chiaki_session_start(&session);
+	if(err != CHIAKI_ERR_SUCCESS)
+	{
+		chiaki_session_fini(&session);
+		return 2;
+	}
+
+	// For testing purpose. Quit after 20 secs.
+	sleep(20);
+	chiaki_session_fini(&session);
+	return 0;
+}

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -41,7 +41,8 @@ struct CLICommand
 
 static const QMap<QString, CLICommand> cli_commands = {
 	{ "discover", { chiaki_cli_cmd_discover } },
-	{ "wakeup", { chiaki_cli_cmd_wakeup } }
+	{ "wakeup", { chiaki_cli_cmd_wakeup } },
+	{ "stream", { chiaki_cli_cmd_stream } }
 };
 #endif
 


### PR DESCRIPTION
**What platform does your feature request apply to?**
Linux (and maybe Windows)

**Is your feature request related to a problem? Please describe.**
I want to stream only the audio from my PS4 to my headless Raspberry Pi using Chiaki. This will allow me to listen to real-time audio from my PS4 from the external speakers that are connected to my Raspberry Pi, which would be very cool!

**Describe the solution you'd like**
I want to be able to run something like this on my Raspberry Pi which will write the audio data to `STDOUT` and other tools like `ffplay` or `mpv` would be able to play this audio stream.
```bash
$ chiaki-cli audiostream --host=192.168.1.2 --registkey=123abc12 --morning=abcdABCDabcdABCDabcdAB== | ffplay -
```
This feature would also allow users to redirect this audio output to a file which would allow them to record the audio from PS4.

**Describe alternatives you've considered**
It is already possible to listen to the audio stream by running the Chiaki GUI but this requires an X server to be available and is unnecessarily more expensive on resources as the video stream from the PS4 is decoded and displayed too.

**Additional context**
I've tried to implement something like this in this draft PR myself and I think I'm pretty close. To try out this draft PR:

The option to build the CLI needs to be `ON` in:
https://github.com/thestr4ng3r/chiaki/blob/736b4835dfee77e34c09faa2623612691f7c1489/CMakeLists.txt#L13

Then compile and run:
```bash
$ chiaki-cli audiostream --host=192.168.1.2 --registkey=123abc12 --morning=abcdABCDabcdABCDabcdAB==
```

This should write what I believe is the OPUS encoded audio to `stderr`. It writes to `stderr` because currently all the chiaki log output is written to `stdout`, so the output would mix up if we were to write the audio data to `stdout` too (it would be a good idea to write logs to `stdout` which AFAIK is the convention, but that is a thing for a another day).
However, when I pipe this audio output from `stderr` to `ffplay` or `mpv` with:
```bash
$ chiaki-cli audiostream --host=192.168.1.2 --registkey=123abc12 --morning=abcdABCDabcdABCDabcdAB== 2>&1 > /dev/null | ffplay -
```

The player fails to recognize it as a valid audio data and nothing can be heard. I'm stuck here and need help to know why the player doesn't recognize and play the audio data received.

Also, I'm a novice in C and low-level stuff so there is a good chance this draft PR can potentially segfault at places or allocate unnecessary memory.