### PR TITLE
Updating flatpak to point to 1.3.0 branch

### DIFF
--- a/scripts/flatpak/com.github.thestr4ng3r.Chiaki.json
+++ b/scripts/flatpak/com.github.thestr4ng3r.Chiaki.json
@@ -89,8 +89,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/thestr4ng3r/chiaki.git",
-		    "tag": "v1.2.1",
-		    "commit": "89c9bd44c354d1351fb9b9a8f9f0aade8077a129"
+		    "tag": "v1.3.0",
+		    "commit": "702d31eb01d37518e77f5c1be3ea493df9f18323"
                 }
             ]
         }


### PR DESCRIPTION
Updated the flatpak file to point to the latest version so that it works again with the PS4 update