### PR TITLE
Added a mouse dbl click Fullscreen toggle

### DIFF
--- a/gui/include/streamwindow.h
+++ b/gui/include/streamwindow.h
@@ -33,6 +33,7 @@ class StreamWindow: public QMainWindow
 		void closeEvent(QCloseEvent *event) override;
 		void mousePressEvent(QMouseEvent *event) override;
 		void mouseReleaseEvent(QMouseEvent *event) override;
+		void mouseDoubleClickEvent(QMouseEvent *event) override;
 		void resizeEvent(QResizeEvent *event) override;
 		void moveEvent(QMoveEvent *event) override;
 		void changeEvent(QEvent *event) override;

--- a/gui/src/streamwindow.cpp
+++ b/gui/src/streamwindow.cpp
@@ -96,6 +96,14 @@ void StreamWindow::mouseReleaseEvent(QMouseEvent *event)
 		session->HandleMouseEvent(event);
 }
 
+void StreamWindow::mouseDoubleClickEvent(QMouseEvent *event)
+{
+	ToggleFullscreen();
+
+	if(session)
+		session->HandleMouseEvent(event);
+}
+
 void StreamWindow::closeEvent(QCloseEvent *event)
 {
 	if(session)

--- a/gui/src/streamwindow.cpp
+++ b/gui/src/streamwindow.cpp
@@ -100,8 +100,7 @@ void StreamWindow::mouseDoubleClickEvent(QMouseEvent *event)
 {
 	ToggleFullscreen();
 
-	if(session)
-		session->HandleMouseEvent(event);
+	QMainWindow::mouseDoubleClickEvent(event);
 }
 
 void StreamWindow::closeEvent(QCloseEvent *event)


### PR DESCRIPTION
I'm trying to create a setup where I can use just the DS4 gamepad, no KB+M, to start up a game session on my RPi and this piece was missing. With this you can double tap the DS4's touchpad (as emulated mouse) in the stream window and it will toggle Fullscreen mode. Similar to VLC or Netflix.

Cheers, Fred